### PR TITLE
Create radar precipitation spec v0.2.0

### DIFF
--- a/docs/mlcast_zarr_spec_v1.0.md
+++ b/docs/mlcast_zarr_spec_v1.0.md
@@ -1,5 +1,5 @@
 # MLCast Radar Data Archive Specification
-**Version 0.1.0**
+**Version 0.2.0**
 **Status: In development**
 
 ## 1. Introduction


### PR DESCRIPTION
I'm working on a proposal for `v0.2.0` that has the following changes relative to the existing spec on `main` (I am calling this previous version `0.1.0` rather than `1.0` since I think it is a good idea to assume need to evolve this spec before a first stable spec):

- restructure the spec document to follow the structure of an `xr.Dataset`, so the high-level headings are `coordinates`, `variables` and `global attributes`. I feel like this makes it easier to understand what should go where
- remove previous `3.3 Data Variable Requirements` since that was already covered by what was previously `5.6 Data Variable Naming and attributes`, which now resides under `4. Variables`

Very keen to hear your thought on this @franchg and @arjj8 :)