### PR TITLE
spec: expand radar precipitation scope to single-radar products

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased](https://github.com/mlcast-community/mlcast-dataset-validator)
+
+### Changed
+
+- Expand the scope of the radar precipitation spec to include single-radar products (previously restricted to multi-radar composites). Single-radar datasets are now in scope provided the valid sensing area supports at least one 256×256 crop at ≤1 km resolution (§3.2), @franchg
+
 ## [v0.3.0](https://github.com/mlcast-community/mlcast-dataset-validator/releases/tag/v0.3.0)
 
 ### Fixed

--- a/mlcast_dataset_validator/specs/source_data/radar_precipitation.py
+++ b/mlcast_dataset_validator/specs/source_data/radar_precipitation.py
@@ -47,18 +47,20 @@ def validate_dataset(ds: xr.Dataset) -> ValidationReport:
 
     ## 1. Introduction
 
-    This document specifies the requirements for 2D radar precipitation and
-    reflectivity composite datasets to be included in the MLCast data collection.
+    This document specifies the requirements for 2D gridded radar precipitation
+    and reflectivity datasets to be included in the MLCast data collection.
     The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
     "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be
     interpreted as described in RFC 2119.
 
     ## 2. Scope
 
-    This specification applies to 2D radar composite datasets (merged from multiple
-    radar sources) intended for machine learning applications in weather and
-    climate research. Single-radar datasets are explicitly excluded from this
-    specification.
+    This specification applies to 2D gridded radar datasets intended for machine
+    learning applications in weather and climate research. Both multi-radar
+    composites (merged from multiple radar sources) and single-radar products are
+    in scope, provided they satisfy the spatial requirements in §3.2 — in
+    particular, that the valid sensing area supports at least one 256×256 pixel
+    crop at a resolution of 1 km or finer.
 
     (see inline comments below for rest of specification)
     """
@@ -85,8 +87,8 @@ def validate_dataset(ds: xr.Dataset) -> ValidationReport:
     spec_text += """
     ### 3.2 Spatial Requirements
 
-    - The dataset MUST provide 2D radar composites with a spatial resolution of 1 kilometer or finer.
-    - The valid sensing area MUST support at least one 256×256 pixel square crop that is fully contained within the radar sensing range.
+    - The dataset MUST provide 2D gridded radar data with a spatial resolution of 1 kilometer or finer.
+    - The valid sensing area MUST support at least one 256×256 pixel square crop that is fully contained within the radar sensing range. This applies equally to multi-radar composites and to single-radar products.
     - The spatial domain, including resolution, size, and geographical coverage, MUST remain constant across all times in the archive.
     """
     report += check_spatial_requirements(


### PR DESCRIPTION
## Summary

- Previously the radar precipitation spec explicitly excluded single-radar datasets and only accepted multi-radar composites. This PR expands the scope to also admit single-radar products, provided they meet the existing §3.2 spatial requirements (≤1 km resolution, and valid sensing area supporting at least one 256×256 crop).
- Motivation: discussion with AEMET on including the Zaragoza regional radar dataset (~1 km, 480×480, fits a 256×256 crop within the sensing disk). The composite-only rule was a proxy for "enough pixels for a decent receptive field" — §3.2 already enforces that directly, so the blanket exclusion was redundant and overly restrictive.

## Changes

- §1 Introduction: "2D gridded radar … datasets" instead of "composite datasets".
- §2 Scope: both multi-radar composites and single-radar products are in scope, subject to §3.2.
- §3.2 Spatial Requirements: reword resolution clause to "2D gridded radar data"; clarify that the 256×256 sensing-area rule applies equally to composites and single-radar products.
- CHANGELOG: add `[Unreleased] > Changed` entry.

## Follow-ups (not in this PR)

- `check_spatial_requirements` currently validates array dimensions, not the valid-data sensing disk. A single-radar product with heavy shadowing could pass by dims alone. Enforcing the disk-level requirement needs a mask/NaN convention that isn't yet in the spec — worth a separate discussion.
- Leif noted that §4.4 should render the allowed `standard_name` values explicitly in the spec docs. Not included here.

## Test plan

- [ ] `uv run mkdocs build --strict` produces a clean spec render with the updated §1 / §2 / §3.2 text.
- [ ] Existing tests still pass (no check logic changed in this PR).